### PR TITLE
Enable per-asset log files

### DIFF
--- a/modules/logger_config.py
+++ b/modules/logger_config.py
@@ -1,9 +1,13 @@
 import logging
 from logging.handlers import TimedRotatingFileHandler, SMTPHandler
 import os
+from datetime import datetime
+
+DEFAULT_LOG_DIR = "/var/data/bitunix-bot"
+os.makedirs(DEFAULT_LOG_DIR, exist_ok=True)
 
 log_dir = "logs"
-os.makedirs(log_dir, exist_ok=True)  # <- This ensures the directory exists
+os.makedirs(log_dir, exist_ok=True)  # backward compatibility for old logs
 
 # Standard logger
 logging.basicConfig(level=logging.INFO)
@@ -43,3 +47,20 @@ reversal_logger.setLevel(logging.INFO)
 reversal_handler = TimedRotatingFileHandler("logs/trade_reversals.log", when="midnight", interval=1, backupCount=7)
 reversal_handler.setFormatter(logging.Formatter('%(message)s'))
 reversal_logger.addHandler(reversal_handler)
+
+_configured_assets = set()
+
+
+def setup_asset_logging(symbol: str) -> None:
+    """Add a file handler for the given trading symbol if not already present."""
+    if not symbol:
+        return
+    if symbol in _configured_assets:
+        return
+    os.makedirs(DEFAULT_LOG_DIR, exist_ok=True)
+    date_str = datetime.utcnow().strftime("%Y_%m%d")
+    file_path = os.path.join(DEFAULT_LOG_DIR, f"{symbol}_{date_str}.log")
+    handler = logging.FileHandler(file_path)
+    handler.setFormatter(logging.Formatter('%(asctime)s | %(levelname)s | %(message)s'))
+    logger.addHandler(handler)
+    _configured_assets.add(symbol)

--- a/modules/webhook_handler.py
+++ b/modules/webhook_handler.py
@@ -4,7 +4,7 @@ from datetime import datetime
 
 from quart import request, jsonify
 
-from modules.logger_config import logger, error_logger
+from modules.logger_config import logger, error_logger, setup_asset_logging
 from modules.loss_tracking import is_daily_loss_limit_exceeded
 from modules.price_feed import validate_and_process_signal
 # from modules.postgres_state_manager import get_or_create_symbol_direction_state, update_position_state
@@ -26,6 +26,7 @@ async def clear_buffered_loss_keys(symbol: str, direction: str):
 
 
 async def webhook_handler(symbol):
+    setup_asset_logging(symbol.upper())
     raw_data = await request.get_data(as_text=True)
     logger.info(f"Raw webhook data: {raw_data}")
     logger.info(f"Request headers: {dict(request.headers)}")

--- a/modules/websocket_handler.py
+++ b/modules/websocket_handler.py
@@ -9,7 +9,7 @@ from datetime import datetime
 import websockets
 
 from modules.config import API_KEY, API_SECRET
-from modules.logger_config import logger
+from modules.logger_config import logger, setup_asset_logging
 from modules.loss_tracking import log_profit_loss
 # from modules.state import position_state, save_position_state, get_or_create_symbol_direction_state
 from modules.redis_state_manager import get_or_create_symbol_direction_state, \
@@ -113,6 +113,7 @@ async def handle_ws_message(message):
         if topic == "position":
             pos_event = data.get("data", {})
             symbol = pos_event.get("symbol", "BTCUSDT")
+            setup_asset_logging(symbol)
             side = pos_event.get("side", "LONG").upper()
             direction = "BUY" if side == "LONG" else "SELL"
             position_event = pos_event.get("event")
@@ -231,6 +232,7 @@ async def handle_ws_message(message):
                 tp_qty = tp_data.get("tpQty")
                 sl_qty = tp_data.get("slQty")
                 symbol = tp_data.get("symbol")
+                setup_asset_logging(symbol)
                 position_id = tp_data.get("positionId")
                 tp_direction = tp_data.get("side", "BUY").upper()
                 position_direction = "SELL" if tp_direction == "BUY" else "BUY"


### PR DESCRIPTION
## Summary
- revert quantity logic changes
- create asset-based log files under `/var/data/bitunix-bot`
- initialize asset logging in webhook and websocket handlers

## Testing
- `python -m py_compile modules/logger_config.py modules/webhook_handler.py modules/websocket_handler.py modules/utils.py modules/orphan_position_checker.py modules/loss_tracking.py`


------
https://chatgpt.com/codex/tasks/task_e_68435a0bd5648332b10d55097e1e2705