### PR TITLE
Update qty tracking

### DIFF
--- a/modules/webhook_handler.py
+++ b/modules/webhook_handler.py
@@ -97,7 +97,8 @@ async def webhook_handler(symbol):
                 state["signal_time"] = signal_time
                 state["trade_action"] = trade_action
                 state["revised_qty"] = market_qty_revised
-                state["total_qty"] = position_existing_qty + market_qty_revised
+                # Track requested size separately until confirmed via websocket
+                state["pending_qty"] = market_qty_revised
 
                 zone_start, zone_bottom = parsed["accumulation_zone"]
                 logger.info(f"[ACC ZONES]: {zone_start}: {zone_bottom}")


### PR DESCRIPTION
## Summary
- track market size as pending quantity from webhook
- when WebSocket reports fill increase, update TP/SL quantities, total qty and reset pending qty
- log old vs new quantities when positions open or update
- keep syntax valid

## Testing
- `python -m py_compile modules/webhook_handler.py modules/websocket_handler.py`

------
https://chatgpt.com/codex/tasks/task_e_68448a39c3948332986658e8b44aa24c